### PR TITLE
Fix issues with SeedMapSetter plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,9 @@ This plugin is intended to bring more variety into the seeding layers and layers
 Example configuration:
 ```json
 {
-    "plugin": "SeedMapSetterr",
+    "plugin": "SeedMapSetter",
     "enabled": true,
-    "seedingLayers": ["Sumari_Seed_v1 RGF USA"],
-    "afterSeedingLayers": ["Narva_RAAS_v1 USA+LightInfantry RGF+LightInfantry"]
+    "seedingLayers": ["Logar_Seed_v1 USA WPMC", "Sumari_Seed_v1 USA WPMC", "Fallujah_Seed_v1 USA WPMC"],
+    "afterSeedingLayers": ["Narva_RAAS_v1 USA+LightInfantry RGF+LightInfantry", "Mutaha_RAAS_v1 USA+LightInfantry RGF+LightInfantry", "Harju_RAAS_v2 USA+LightInfantry RGF+LightInfantry"]
 }
 ```


### PR DESCRIPTION
Rather large rework. Seems like `AdminChangeLayer` via RCON doesn't trigger the change for some reason, so I opted for combination of `AdminSetNextLayer` and `AdminEndMatch` which seems to work. The next layer is set with 5 minutes delay, just to be sure it doesn't cause some kind of conflict during match end phase. I've also removed the condition about the next layer being set since SquadJS loads the info from `ShowServerInfo` and there the next layer is alwas set to something it seems.